### PR TITLE
PaaS VCAP services parsing

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,6 +1,5 @@
 .idea/
 .vscode/
-app/
 test/
 Dockerfile
 .dockerignore

--- a/app/session.ts
+++ b/app/session.ts
@@ -37,6 +37,12 @@ import {
 import express from "express";
 
 const getRedisClientOptions = (): ClientOpts => {
+  const redisUrl = getRedisSessionUrl();
+  // regex match for rediss from vcap env.
+  if (redisUrl.match(/rediss:\/\/\w+:\w+@[\w.-]*:[0-9]+/)) {
+    return { url: redisUrl };
+  }
+
   return process.env.NODE_ENV.trim() === "production"
     ? {
         url: "rediss://" + getRedisSessionUrl() + ":" + getRedisPort(),

--- a/app/utils/vcap-utils.ts
+++ b/app/utils/vcap-utils.ts
@@ -1,0 +1,6 @@
+const cfenv = require("cfenv");
+const appEnv = cfenv.getAppEnv();
+
+export const getRedisServiceUrl = (): string => {
+  return appEnv.getServiceURL("session-cache");
+};

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,6 @@
 // This is for the API authentication
+import { getRedisServiceUrl } from "./app/utils/vcap-utils";
+
 export const getDeclarationApiDiscoveryUri = (): string => {
   return process.env.DISCOVERY_ENDPOINT;
 };
@@ -12,7 +14,7 @@ export const getRedisAuthToken = (): string => {
   return process.env.REDIS_AUTH_TOKEN;
 };
 export const getRedisSessionUrl = (): string => {
-  return process.env.REDIS_SESSION_URL;
+  return getRedisServiceUrl() || process.env.REDIS_SESSION_URL;
 };
 export const getRedisSessionSecret = (): string => {
   return process.env.SESSION_SECRET;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "precompile": "node generate-files.js",
     "start": "node build/main.js",
-    "build": "yarn precompile && webpack --config webpack/webpack.dev.js",
+    "build": "yarn precompile && webpack --config webpack/webpack.prod.js",
     "buildAndStart": "yarn build && yarn start",
     "build-sass": "rm -rf ./build/style.css && node-sass --include-path scss app/assets/scss/application.scss build/style.css",
     "depcheck": "depcheck",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "engines": {
-    "node": "15.12.0"
+    "node": "15.14.0"
   },
   "scripts": {
     "precompile": "node generate-files.js",
@@ -53,6 +53,7 @@
   "dependencies": {
     "@godaddy/terminus": "^4.4.1",
     "babel-loader": "^8.0.6",
+    "cfenv": "^1.2.4",
     "connect-redis": "^4.0.3",
     "cookie-parser": "^1.4.4",
     "copy-webpack-plugin": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2588,6 +2593,15 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cfenv@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/cfenv/-/cfenv-1.2.4.tgz#4f34b431038fd899b370abd5e3f5046a6a451908"
+  integrity sha512-jWQ+3UXZauYyOXwHpMm74C0wM7+LDQmgMxWBGchg4as7+YyTL0pyx/CZ3dEvJyZVOB4SgKATc5naJky6cd9zYw==
+  dependencies:
+    js-yaml "4.0.x"
+    ports "1.1.x"
+    underscore "1.12.x"
 
 chai-as-promised@^7.1.1:
   version "7.1.1"
@@ -6062,6 +6076,13 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@4.0.x:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -8026,6 +8047,11 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+ports@1.1.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ports/-/ports-1.1.0.tgz#b701aa285e95dae8c96cda275217724a1f7f6c60"
+  integrity sha1-twGqKF6V2ujJbNonUhdySh9/bGA=
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -10295,6 +10321,11 @@ undefsafe@^2.0.2:
   integrity sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
   dependencies:
     debug "^2.2.0"
+
+underscore@1.12.x:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Things Changed
- Bumping up required node engine version to match .nvmrc file.
- Adding cfenv dependency.
- Updated .cfignore, we need the template files - in future they could be pulled in via webpack.
- Added a vcap-utils file to help fetch the VCAP services redis url, if this doesnt exist, it will attempt to revert to env vars.
- Reverted the changes to use `webpack.prod.js`.