### PR TITLE
env-vars: Pulling in the key and cert from the env rather than a file.

### DIFF
--- a/app/features/oauth2/token/token.ts
+++ b/app/features/oauth2/token/token.ts
@@ -1,13 +1,8 @@
-import * as fs from "fs";
 import hashSessionId from "../../../utils/hashSessionId";
 
 const jwt = require("jsonwebtoken");
-const privateSigningKey = fs.readFileSync(
-  "./keys/private-di-ipv-atp-playbox.pem"
-);
-const publicSigningKey = fs.readFileSync(
-  "./keys/public-di-ipv-atp-playbox.pem"
-);
+const privateSigningKey = process.env.DI_IPV_SIGN_KEY;
+const publicSigningKey = process.env.DI_IPV_SIGN_CERT;
 
 export const audience = "urn:di:ipv:orchestrator-stub";
 export const issuer = "urn:di:ipv:ipv-atp-playbox";


### PR DESCRIPTION
## Whats changed

- Pulling in the keys and certs from env rather than file, which would need to be packaged up in build.