### PR TITLE
bau: Reorder Dockerfile steps to improve skaffold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM node:15.14.0@sha256:608bba799613b1ebf754034ae008849ba51e88b23271412427b76d60ae0d0627 AS builder
 
-COPY --chown=node:node . /home/node/app
+COPY --chown=node:node ./package.json yarn.lock /home/node/app/
 WORKDIR /home/node/app
-RUN yarn && yarn build
+RUN yarn
+
+COPY --chown=node:node ./scripts/* /home/node/app/scripts/
 RUN ./scripts/generate-key-pair-for-dev.sh
+
+COPY --chown=node:node . /home/node/app
+RUN yarn build
 
 FROM node:15.14.0-alpine@sha256:6edd37368174c15d4cc59395ca2643be8e2a1c9846714bc92c5f5c5a92fb8929
 


### PR DESCRIPTION
`skaffold` runs a rebuild on each non-sync change. The current Dockerfile will rerun `yarn install` on any change at all.

This PR improves the Docker layer caching by:
- separate `yarn install` from `yarn build`
- reposition the key generation after install, but before build