### PR TITLE
BAU: updating redis config to use a URL.

### DIFF
--- a/app/session.ts
+++ b/app/session.ts
@@ -38,19 +38,15 @@ import express from "express";
 
 const getRedisClientOptions = (): ClientOpts => {
   const redisUrl = getRedisSessionUrl();
+
   // regex match for rediss from vcap env.
   if (redisUrl.match(/rediss:\/\/\w+:\w+@[\w.-]*:[0-9]+/)) {
     return { url: redisUrl };
   }
 
-  return process.env.NODE_ENV.trim() === "production"
-    ? {
-        url: "rediss://" + getRedisSessionUrl() + ":" + getRedisPort(),
-        password: getRedisAuthToken(),
-      }
-    : {
-        url: "redis://" + getRedisSessionUrl() + ":" + getRedisPort(),
-      };
+  return {
+    url: "redis://" + getRedisSessionUrl() + ":" + getRedisPort(),
+  };
 };
 
 export const getRedisClient = (): redis.RedisClient => {

--- a/config.ts
+++ b/config.ts
@@ -14,7 +14,7 @@ export const getRedisAuthToken = (): string => {
   return process.env.REDIS_AUTH_TOKEN;
 };
 export const getRedisSessionUrl = (): string => {
-  return getRedisServiceUrl() || process.env.REDIS_SESSION_URL;
+  return  process.env.REDIS_SESSION_URL || getRedisServiceUrl();
 };
 export const getRedisSessionSecret = (): string => {
   return process.env.SESSION_SECRET;


### PR DESCRIPTION
- Specifying NODE_ENV env var in node container will not update the NODE_ENV retrieved with process.env weirdly.