### PR TITLE
BAU: Removing the redis env var when deploying to PaaS.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,8 +9,6 @@ applications:
     env:
       SESSION_SECRET: your_session_secret
       LOG_SESSION: "false"
-      REDIS_SESSION_URL: "127.0.0.1"
-      REDIS_PORT: "6379"
       SESSION_COOKIE_MAX_AGE: "1200000"
       SESSION_COOKIE_SECURE: "false"
       ENVIRONMENT: "dev"


### PR DESCRIPTION
## Whats changed

- Removing the redis env variables when deploying to PaaS. This caused a crash as it was trying to connect to redis on localhost.