### PR TITLE
BAU: restore previously entered data onto passport atp

### DIFF
--- a/app/features/atp/passport/ui/idx/controller.ts
+++ b/app/features/atp/passport/ui/idx/controller.ts
@@ -116,26 +116,19 @@ const passportValidationMiddleware = [
 ];
 
 const getPassport = (req: Request, res: Response): void => {
-  // if (!req.session.userData.passport) {
-  //   req.session.userData.passport = {};
-  // }
+  if (!req.session.identityEvidence) {
+    req.session.identityEvidence = [];
+  }
 
-  // const {
-  //   number,
-  //   surname,
-  //   givenNames,
-  //   dob,
-  //   issued,
-  //   expiry,
-  // } = req.session.userData.passport;
-
-  const number = null;
-  const surname = null;
-  const givenNames = null;
-
-  const dob = null;
-  const issued = null;
-  const expiry = null;
+  const sessionAttributes =
+    req.session.identityEvidence.map((evidence) => evidence.attributes)[0] ||
+    {};
+  const number = sessionAttributes ? sessionAttributes.passportNumber : null;
+  const surname = sessionAttributes ? sessionAttributes.surname : null;
+  const givenNames = sessionAttributes ? sessionAttributes.forenames : null;
+  const dob = sessionAttributes ? sessionAttributes.dateOfBirth : null;
+  const issued = sessionAttributes ? sessionAttributes.issued : null;
+  const expiry = sessionAttributes ? sessionAttributes.expiryDate : null;
 
   const values = {
     number,
@@ -171,6 +164,13 @@ const postPassport = async (
         "-" +
         req.body["dobDay"].padStart(2, "0") +
         "T00:00:00",
+      issued:
+        req.body["issuedDay"] +
+        "-" +
+        req.body["issuedMonth"].padStart(2, "0") +
+        "-" +
+        req.body["issuedDay"].padStart(2, "0") +
+        "T00:00:00",
       expiryDate:
         req.body["expiryYear"] +
         "-" +
@@ -193,11 +193,20 @@ const postPassport = async (
     identityEvidence.atpResponse = decoded;
     req.session.identityEvidence = req.session.identityEvidence || [];
     req.session.identityEvidence.push(identityEvidence);
-
     addToFill(req, "dob", {
       dobDay: req.body["dobDay"],
       dobMonth: req.body["dobMonth"],
       dobYear: req.body["dobYear"],
+    });
+    addToFill(req, "expiry", {
+      expiryDay: req.body["expiryDay"],
+      expiryMonth: req.body["expiryMonth"],
+      expiryYear: req.body["expiryYear"],
+    });
+    addToFill(req, "issued", {
+      issuedDay: req.body["issuedDay"],
+      issuedMonth: req.body["issuedMonth"],
+      issuedYear: req.body["issuedYear"],
     });
     addToList(req, "givenNames", {
       givenNames: req.body["givenNames"],

--- a/app/features/atp/passport/ui/idx/view.njk
+++ b/app/features/atp/passport/ui/idx/view.njk
@@ -119,7 +119,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.day" | translate,
                         classes: 'govuk-input--width-2 govuk-input--error' if (errors['issuedDay'] or errors['issued']) else 'govuk-input--width-2',
-                        value: issuedDay
+                        value: issuedDay or autoFill({ name: "issued", list: autoInput, input: "issuedDay" })
                     },
                     {
                         id:"issuedMonth",
@@ -127,7 +127,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.month" | translate,
                         classes: 'govuk-input--width-2 govuk-input--error' if (errors['issuedMonth'] or errors['issued']) else 'govuk-input--width-2',
-                        value: issuedMonth
+                        value: issuedMonth or autoFill({ name: "issued", list: autoInput, input: "issuedMonth" })
                     },
                     {
                         id:"issuedYear",
@@ -135,7 +135,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.year" | translate,
                         classes: 'govuk-input--width-4 govuk-input--error' if (errors['issuedYear'] or errors['issued']) else 'govuk-input--width-4',
-                        value: issuedYear
+                        value: issuedYear or autoFill({ name: "issued", list: autoInput, input: "issuedYear" })
                     }
                 ],
                 fieldset: {
@@ -158,7 +158,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.day" | translate,
                         classes: 'govuk-input--width-2 govuk-input--error' if (errors['expiryDay'] or errors['expiry']) else 'govuk-input--width-2',
-                        value: expiryDay
+                        value: expiryDay or autoFill({ name: "expiry", list: autoInput, input: "expiryDay" })
                     },
                     {
                         id:"expiryMonth",
@@ -166,7 +166,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.month" | translate,
                         classes: 'govuk-input--width-2 govuk-input--error' if (errors['expiryMonth'] or errors['expiry']) else 'govuk-input--width-2',
-                        value: expiryMonth
+                        value: expiryMonth or autoFill({ name: "expiry", list: autoInput, input: "expiryMonth" })
                     },
                     {
                         id:"expiryYear",
@@ -174,7 +174,7 @@
                         autocomplete: "off",
                         label: "common.dateInput.year" | translate,
                         classes: 'govuk-input--width-4 govuk-input--error' if (errors['expiryYear'] or errors['expiry']) else 'govuk-input--width-4',
-                        value: expiryYear
+                        value: expiryYear or autoFill({ name: "expiry", list: autoInput, input: "expiryYear" })
                     }
                 ],
                 fieldset: {


### PR DESCRIPTION
Pulling the data from the new identityEvidence interface in the session
Edited the view to now be able to autofill expiry