### PR TITLE
PYI-189: Allowing to set activity history score.

### DIFF
--- a/app/features/atp/activity-history/ui/idx/controller.ts
+++ b/app/features/atp/activity-history/ui/idx/controller.ts
@@ -7,6 +7,7 @@ const template = "atp/activity-history/ui/idx/view.njk";
 const logger: Logger = new Logger();
 
 interface ActivityHistory {
+  activityHistoryScore?: any;
   activityHistoryData: any;
 }
 
@@ -31,7 +32,12 @@ const postActivityHistory = async (
     req.body["activityHistoryData"]
   );
 
+  const activityHistoryScore = getJsonFromString(
+    req.body["activityHistoryScore"]
+  );
+
   const activityHistory: ActivityHistory = {
+    activityHistoryScore: activityHistoryScore,
     activityHistoryData: activityHistoryData,
   };
 

--- a/app/features/atp/activity-history/ui/idx/view.njk
+++ b/app/features/atp/activity-history/ui/idx/view.njk
@@ -21,12 +21,12 @@
                 {{ govukInput({
                     label: {
                         text: "Activity History Score",
-                        classes: "govuk-label--l",
+                        classes: "govuk-label--l"
                     },
                     id: "activityHistoryScore",
                     name: "activityHistoryScore",
                     value: number,
-                    autocomplete: "off",
+                    autocomplete: "off"
                 }) }}
                 {{ govukTextarea({
                     name: "activityHistoryData",

--- a/app/features/atp/activity-history/ui/idx/view.njk
+++ b/app/features/atp/activity-history/ui/idx/view.njk
@@ -18,6 +18,16 @@
             <p>Please enter the following information</p>
             <form action="/activity-history" method="post" class="form" novalidate>
                 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+                {{ govukInput({
+                    label: {
+                        text: "Activity History Score",
+                        classes: "govuk-label--l",
+                    },
+                    id: "activityHistoryScore",
+                    name: "activityHistoryScore",
+                    value: number,
+                    autocomplete: "off",
+                }) }}
                 {{ govukTextarea({
                     name: "activityHistoryData",
                     id: "activityHistoryData",


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Adding in a textbox to set activity history score.

### Why did it change

We would like to provide a score to mock without knowing the JSON data

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-189](https://govukverify.atlassian.net/browse/PYI-189)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
