### PR TITLE
PYI-190: Adding in a way to mock fraud scores.

### DIFF
--- a/app/features/atp/fraud-check/ui/idx/controller.ts
+++ b/app/features/atp/fraud-check/ui/idx/controller.ts
@@ -7,6 +7,7 @@ const template = "atp/fraud-check/ui/idx/view.njk";
 const logger: Logger = new Logger();
 
 interface FraudCheck {
+  fraudCheckScore?: any;
   fraudCheckData: any;
 }
 
@@ -24,10 +25,12 @@ const getJsonFromString = (data: string): Record<string, any> => {
 };
 
 const postFraudCheck = async (req: Request, res: Response): Promise<void> => {
-  const fraudCheckData = getJsonFromString(req.body["activityHistoryData"]);
+  const fraudCheckData = getJsonFromString(req.body["fraudCheckData"]);
+  const fraudCheckScore = getJsonFromString(req.body["fraudCheckScore"]);
 
   const fraudCheck: FraudCheck = {
     fraudCheckData: fraudCheckData,
+    fraudCheckScore: fraudCheckScore
   };
 
   req.session.sessionData.fraudChecks =

--- a/app/features/atp/fraud-check/ui/idx/view.njk
+++ b/app/features/atp/fraud-check/ui/idx/view.njk
@@ -18,6 +18,16 @@
             <p>Please enter the following information</p>
             <form action="/fraud-check" method="post" class="form" novalidate>
                 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+                {{ govukInput({
+                    label: {
+                        text: "Fraud Score",
+                        classes: "govuk-label--l"
+                    },
+                    id: "fraudCheckScore",
+                    name: "fraudCheckScore",
+                    value: number,
+                    autocomplete: "off"
+                }) }}
                 {{ govukTextarea({
                     name: "fraudCheckData",
                     id: "fraudCheckData",


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Adding in a way to mock fraud score by inputing it as a string on form.

### Why did it change

We need a way to mock fraud scores

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-190](https://govukverify.atlassian.net/browse/PYI-190)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

